### PR TITLE
Timeline bullet unicode fix

### DIFF
--- a/_sass/timeline.scss
+++ b/_sass/timeline.scss
@@ -20,7 +20,7 @@ ul.timeline {
 
     &:after {
       /* bullets */
-      content: "●";
+      content: "\25cf"; /* black circle */
       color: $accent;
       font-size: 18px;
       position: absolute;


### PR DESCRIPTION
I got a weird state when I was looking at the production site, where the dot on the timeline was not coming through as the correct character. It fixed itself on a subsequent reload, so I couldn't screenshot it. But this fix should be more reliable.